### PR TITLE
Add xxhash benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ metrohash = "1"
 fnv = "1"
 # pinned otherwise it pulls getrandom with the std feature. With the dep resolver in Rust 1.36.0 this does not build on no-std.
 twox-hash = "1.6.0"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 
 [features]
 mum32bit = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rand_core = "0.6"
 metrohash = "1"
 fnv = "1"
 # pinned otherwise it pulls getrandom with the std feature. With the dep resolver in Rust 1.36.0 this does not build on no-std.
-twox-hash = "=1.6.0"
+twox-hash = "1.6.0"
 
 [features]
 mum32bit = []

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -108,4 +108,7 @@ impl_bench!(metro128, metrohash::MetroHash128);
 impl_bench!(fnvh, fnv::FnvHasher);
 impl_bench!(xxh, twox_hash::XxHash);
 
+//xxhash-rust xxh3
+impl_bench!(xxh3, xxhash_rust::xxh3::Xxh3);
+
 impl_bench!(wyhash_bench, wyhash::v1::WyHash);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -106,9 +106,12 @@ impl_bench!(std_hash_map, DefaultHasher);
 impl_bench!(metro64, metrohash::MetroHash64);
 impl_bench!(metro128, metrohash::MetroHash128);
 impl_bench!(fnvh, fnv::FnvHasher);
-impl_bench!(xxh, twox_hash::XxHash);
+// impl_bench!(xxh, twox_hash::XxHash);
 
 //xxhash-rust xxh3
 impl_bench!(xxh3, xxhash_rust::xxh3::Xxh3);
 
-impl_bench!(wyhash_bench, wyhash::v1::WyHash);
+//impl_bench!(wyhash_bench, wyhash::v1::WyHash);
+
+impl_bench!(wyhash_bench3, wyhash::final3::WyHash);
+

--- a/src/final3/functions.rs
+++ b/src/final3/functions.rs
@@ -111,7 +111,7 @@ pub fn make_secret(seed: u64) -> [u64; 4] {
         loop {
             secret[i] = 0;
             for j in (0..64).step_by(8) {
-                secret[i] |= u64::from(c[((wyrng(&mut seed) as usize) % c.len())]) << j;
+                secret[i] |= u64::from(c[(wyrng(&mut seed) as usize) % c.len()]) << j;
             }
             if secret[i] % 2 == 0 {
                 continue;

--- a/src/final3/traits.rs
+++ b/src/final3/traits.rs
@@ -46,7 +46,7 @@ impl Hasher for WyHash {
     }
     #[inline]
     fn finish(&self) -> u64 {
-        wyhash_finish(self.a, self.b, self.seed, self.size as u64, self.secret[1])
+        wyhash_finish(self.a, self.b, self.seed, self.size, self.secret[1])
     }
 }
 


### PR DESCRIPTION
I wanted to compare the more upto date xxhash-rust (xxh3) with wyhash
it seems smaller hashes wyhash is faster and larger hashes wyhash is faster

test wyhash_bench::hash_004_bytes    ... bench:           2 ns/iter (+/- 0) = 2000 MB/s
test wyhash_bench::hash_007_bytes    ... bench:           2 ns/iter (+/- 0) = 3500 MB/s
test wyhash_bench::hash_008_bytes    ... bench:           2 ns/iter (+/- 0) = 4000 MB/s
test wyhash_bench::hash_009_bytes    ... bench:           3 ns/iter (+/- 0) = 3000 MB/s
test wyhash_bench::hash_012_bytes    ... bench:           3 ns/iter (+/- 0) = 4000 MB/s
test wyhash_bench::hash_016_bytes    ... bench:           3 ns/iter (+/- 0) = 5333 MB/s
test wyhash_bench::hash_032_bytes    ... bench:           2 ns/iter (+/- 0) = 16000 MB/s
test wyhash_bench::hash_128_bytes    ... bench:           7 ns/iter (+/- 1) = 18285 MB/s
test wyhash_bench::hash_1_kilo_bytes ... bench:          56 ns/iter (+/- 10) = 18285 MB/s
test wyhash_bench::hash_1_mega_bytes ... bench:      69,603 ns/iter (+/- 7,315) = 15065 MB/s
test wyhash_bench::hash_256_bytes    ... bench:          14 ns/iter (+/- 2) = 18285 MB/s
test wyhash_bench::hash_512_bytes    ... bench:          27 ns/iter (+/- 2) = 18962 MB/s
test wyhash_bench::hash_u64          ... bench:           0 ns/iter (+/- 0) = 8000 MB/s
test xxh3::hash_004_bytes            ... bench:          11 ns/iter (+/- 1) = 363 MB/s
test xxh3::hash_007_bytes            ... bench:          17 ns/iter (+/- 4) = 411 MB/s
test xxh3::hash_008_bytes            ... bench:          12 ns/iter (+/- 3) = 666 MB/s
test xxh3::hash_009_bytes            ... bench:          16 ns/iter (+/- 3) = 562 MB/s
test xxh3::hash_012_bytes            ... bench:          16 ns/iter (+/- 2) = 750 MB/s
test xxh3::hash_016_bytes            ... bench:          11 ns/iter (+/- 5) = 1454 MB/s
test xxh3::hash_032_bytes            ... bench:          11 ns/iter (+/- 1) = 2909 MB/s
test xxh3::hash_128_bytes            ... bench:          14 ns/iter (+/- 3) = 9142 MB/s
test xxh3::hash_1_kilo_bytes         ... bench:          52 ns/iter (+/- 4) = 19692 MB/s
test xxh3::hash_1_mega_bytes         ... bench:      49,757 ns/iter (+/- 12,517) = 21073 MB/s
test xxh3::hash_256_bytes            ... bench:          24 ns/iter (+/- 1) = 10666 MB/s
test xxh3::hash_512_bytes            ... bench:          33 ns/iter (+/- 7) = 15515 MB/s
test xxh3::hash_u64                  ... bench:          11 ns/iter (+/- 3) = 727 MB/s