### PR TITLE
Added optional support for mem-dbg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable better performance on 32-bit systems via the `mum32bit` feature.
 - Benchmarks.
 - Added derives for `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Copy`, and `Hash` for all structs where applicable in the crate.
+- Added optional support for [`mem_dbg`](https://github.com/zommiommy/mem_dbg-rs), a memory requirements estimation tool.
+- Added feature `mem_dbg` to enable the optional support for `mem_dbg`.
+- Added feature `std` to enable optionally the standard library.
 
 ### Changed
 - [breaking-change] Changed default version to `final3`. The previous version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ include = [
 edition = "2018"
 
 [dependencies]
+mem_dbg = {version="0.2.4", optional=true}
 rand_core = "0.6"
 
 [dev-dependencies]
@@ -31,6 +32,8 @@ twox-hash = "=1.6.0"
 
 [features]
 mum32bit = []
+std = []
+mem_dbg = ["dep:mem_dbg", "std"]
 
 [workspace]
 members = ["comparison"]

--- a/src/final3/traits.rs
+++ b/src/final3/traits.rs
@@ -5,6 +5,7 @@ use rand_core::{impls, Error, RngCore, SeedableRng};
 
 /// WyHash hasher
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Copy, Hash)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct WyHash {
     seed: u64,
     a: u64,
@@ -52,6 +53,7 @@ impl Hasher for WyHash {
 
 /// WyRng random number generator
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct WyRng(u64);
 
 impl RngCore for WyRng {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/wyhash/0.5.0")]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs, unsafe_code)]
 
 /// WyHash version 1

--- a/src/v1/traits.rs
+++ b/src/v1/traits.rs
@@ -4,6 +4,7 @@ use rand_core::{impls, Error, RngCore, SeedableRng};
 
 /// WyHash hasher
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct WyHash {
     h: u64,
     size: u64,
@@ -36,6 +37,7 @@ impl Hasher for WyHash {
 
 /// WyRng random number generator
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct WyRng(u64);
 
 impl RngCore for WyRng {


### PR DESCRIPTION
Hi - I have added optional support for the [mem-dbg](https://github.com/zommiommy/mem_dbg-rs) crate, guarded behind the mem-dbg feature. I have also added optional support for enabling std, which is needed at this time for mem-dbg.